### PR TITLE
:sparkles: Implement code transitions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@ node_modules/
 lib/
 dist/
 output/
+
+.idea/
+.vscode/

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@codemirror/language": "^6.10.0",
+        "@lezer/common": "^1.2.0",
         "@lezer/highlight": "^1.2.0",
         "@lezer/javascript": "^1.4.12",
         "@lezer/lr": "^1.3.14",
@@ -827,9 +828,9 @@
       }
     },
     "node_modules/@lezer/common": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.1.0.tgz",
-      "integrity": "sha512-XPIN3cYDXsoJI/oDWoR2tD++juVrhgIago9xyKhZ7IhGlzdDM9QgC8D8saKNCz5pindGcznFr2HBSsEQSWnSjw=="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.2.0.tgz",
+      "integrity": "sha512-Wmvlm4q6tRpwiy20TnB3yyLTZim38Tkc50dPY8biQRwqE+ati/wD84rm3N15hikvdT4uSg9phs9ubjvcLmkpKg=="
     },
     "node_modules/@lezer/highlight": {
       "version": "1.2.0",
@@ -6384,9 +6385,9 @@
       }
     },
     "@lezer/common": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.1.0.tgz",
-      "integrity": "sha512-XPIN3cYDXsoJI/oDWoR2tD++juVrhgIago9xyKhZ7IhGlzdDM9QgC8D8saKNCz5pindGcznFr2HBSsEQSWnSjw=="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.2.0.tgz",
+      "integrity": "sha512-Wmvlm4q6tRpwiy20TnB3yyLTZim38Tkc50dPY8biQRwqE+ati/wD84rm3N15hikvdT4uSg9phs9ubjvcLmkpKg=="
     },
     "@lezer/highlight": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   "homepage": "",
   "dependencies": {
     "@codemirror/language": "^6.10.0",
+    "@lezer/common": "^1.2.0",
     "@lezer/highlight": "^1.2.0",
     "@lezer/javascript": "^1.4.12",
     "@lezer/lr": "^1.3.14",

--- a/src/Code.tsx
+++ b/src/Code.tsx
@@ -1,352 +1,110 @@
 import {
-  DesiredLength,
-  PossibleCanvasStyle,
-  Shape,
-  ShapeProps,
-  colorSignal,
   computed,
+  DesiredLength,
   initial,
   parser,
+  Shape,
+  ShapeProps,
   signal,
 } from '@motion-canvas/2d';
 import {
-  Color,
-  ColorSignal,
   SerializedVector2,
+  Signal,
   SignalValue,
   SimpleSignal,
-  ThreadGenerator,
-  TimingFunction,
-  Vector2,
-  createComputed,
-  createSignal,
-  useLogger,
+  unwrap,
 } from '@motion-canvas/core';
-import {highlightTree} from '@lezer/highlight';
-import {Parser} from '@lezer/common';
-import {parser as jsParser} from '@lezer/javascript';
-import {HighlightStyle} from '@codemirror/language';
-import {Extension} from '@codemirror/state';
-import {correctWhitespace} from './correctWhitespace';
-
-export type CodePoint = [number, number];
-export type CodeRange = [CodePoint, CodePoint];
-export type CodeInit = [string, SignalValue<string>][];
-
-const v2 = Vector2.createSignal([1, 2]);
-const a = CODE`const test = new ${() => v2().toString()}`;
-
-export class CodeSignal {
-  public readonly zeroText = createSignal<CodeInit>([['', undefined]]);
-  public readonly zeroCombined = createComputed(() => {
-    return this.zeroText()
-      .map(([text, signal]) => {
-        if (signal === undefined) {
-          return text;
-        }
-        if (signal instanceof Function) {
-          return text + signal();
-        }
-        return text + signal;
-      })
-      .join('');
-  });
-  public readonly zeroParsed = createComputed(() =>
-    this.parser.parse(this.zeroCombined()),
-  );
-
-  public readonly oneText = createSignal<CodeInit>([['', undefined]]);
-  public readonly oneCombined = createComputed(() => {
-    return this.oneText()
-      .map(([text, signal]) => {
-        if (signal === undefined) {
-          return text;
-        }
-        if (signal instanceof Function) {
-          return text + signal();
-        }
-        return text + signal;
-      })
-      .join('');
-  });
-  public readonly oneParsed = createComputed(() =>
-    this.parser.parse(this.oneCombined()),
-  );
-  public readonly progress = createSignal(0);
-
-  public constructor(
-    private readonly parser: Parser,
-    private readonly dialect: string,
-    init: string | CodeInit,
-  ) {
-    const fixedInit: CodeInit =
-      typeof init === 'string' ? [[init, undefined]] : init;
-    this.zeroText(fixedInit);
-    this.oneText(fixedInit);
-  }
-
-  public *append(
-    text: SignalValue<string>,
-    duration: number,
-    timingFunction: TimingFunction,
-  ): ThreadGenerator {
-    const last = this.oneText().slice(-1)[0];
-    if (last[1] === undefined) {
-      if (text instanceof Function) {
-        this.oneText([...this.oneText().slice(0, -1), [last[0], text]]);
-      } else {
-        this.oneText([
-          ...this.oneText().slice(0, -1),
-          [last[0] + text, undefined],
-        ]);
-      }
-    } else {
-      if (text instanceof Function) {
-        this.oneText([...this.oneText(), ['', text]]);
-      } else {
-        this.oneText([...this.oneText(), [text, undefined]]);
-      }
-    }
-    yield* this.progress(1, duration, timingFunction);
-    this.zeroText(this.oneText());
-  }
-}
+import {CodeHighlighter} from '@components/CodeHighlighter';
+import {
+  CodeScope,
+  parseCodeScope,
+  PossibleCodeScope,
+  resolveScope,
+} from '@components/CodeScope';
+import {CodeCursor} from '@components/CodeCursor';
 
 export interface CodeProps extends ShapeProps {
-  style?: SignalValue<HighlightStyle | Extension>;
-  parser?: SignalValue<Parser>;
-  dialect?: SignalValue<string>;
-  code?: SignalValue<string>;
-  fallbackColor?: SignalValue<PossibleCanvasStyle>;
+  highlighter?: CodeHighlighter;
+  dialect: SignalValue<string>;
+  code?: SignalValue<PossibleCodeScope>;
   children?: never;
 }
 
-function zip<A, B>(a: A[], b: B[]): [A, B][] {
-  return a.map((a, i) => [a, b[i]]);
-}
-
-export function CODE(
-  strings: TemplateStringsArray,
-  ...tags: SignalValue<string>[]
-) {
-  return zip([...strings], tags);
-}
-
 export class Code extends Shape {
-  @initial(jsParser)
-  @signal()
-  public declare readonly parser: SimpleSignal<Parser, this>;
-
   @signal()
   public declare readonly dialect: SimpleSignal<string, this>;
 
-  @initial(new Color('red'))
-  @colorSignal()
-  public declare readonly fallbackColor: ColorSignal<this>;
-
-  private oldStyle = createSignal<HighlightStyle | null>(null);
-  private styleProgress = createSignal<number | null>(null);
-
+  @initial('')
+  @parser(parseCodeScope)
   @signal()
-  public declare readonly style: SimpleSignal<HighlightStyle, this>;
+  public declare readonly code: Signal<PossibleCodeScope, CodeScope, this>;
 
-  protected *tweenStyle(
-    value: HighlightStyle,
-    duration: number,
-    timingFunction: TimingFunction,
-  ): ThreadGenerator {
-    this.oldStyle(this.style());
-    this.style(value);
-    this.styleProgress(0);
-    yield* this.styleProgress(1, duration, timingFunction);
-    this.styleProgress(null);
-    this.oldStyle(null);
-  }
-
-  @parser(function (this: Code, value: string): string {
-    return correctWhitespace(value);
-  })
-  @signal()
-  public declare readonly code: SimpleSignal<string, this>;
-
+  /**
+   * Get the currently displayed code as a string.
+   */
   @computed()
-  protected parsed() {
-    return this.parser().parse(this.code());
+  public parsed(): string {
+    return resolveScope(this.code(), scope => unwrap(scope.progress) > 0.5);
   }
 
   @computed()
-  protected oldHighlighted() {
-    const oldStyle = this.oldStyle();
-    if (!oldStyle) {
-      return null;
-    }
-    return this.highlight(oldStyle);
-  }
+  public highlighterCache() {
+    if (!this.highlighter || !this.highlighter.initialize()) return null;
+    const code = this.code();
+    const before = resolveScope(code, false);
+    const after = resolveScope(code, true);
+    const dialect = this.dialect();
 
-  @computed()
-  protected newHighlighted() {
-    return this.highlight(this.style());
-  }
-
-  @computed()
-  protected highlighted() {
-    if (this.styleProgress() === null) {
-      return this.newHighlighted();
-    }
-    const zipped = this.newHighlighted().map((token, i) => [
-      token,
-      this.oldHighlighted()[i],
-    ]);
-
-    const blendHsl = (c1: string, c2: string, amount: number): string => {
-      return new Color(c1).mix(c2, amount, 'hsl').hex();
+    return {
+      before: this.highlighter.prepare(before, dialect),
+      after: this.highlighter.prepare(after, dialect),
     };
-
-    return zipped.map(([newToken, oldToken]) => ({
-      token: newToken.token,
-      color: blendHsl(newToken.color, oldToken.color, 1 - this.styleProgress()),
-    }));
   }
 
-  @computed()
-  protected tokens() {
-    const segmenter = new Intl.Segmenter('en', {
-      granularity: 'word',
-    });
-    return this.highlighted()
-      .map(({token, color}) => {
-        // Split tokens so that we preserve emoji and CJK characters.
-        return (
-          Array.from(segmenter.segment(token), c => c.segment)
-            // Combine non-spaced characters within the same token back into
-            // segments so that we can draw ligatures.
-            .reduce(
-              (a, i) =>
-                !i.match(/\s/)
-                  ? [...a.slice(0, -1), a.slice(-1)[0].concat(i)]
-                  : [...a, i],
-              [''],
-            )
-            .map(char => ({
-              color,
-              token: char,
-            }))
-        );
-      })
-      .flat();
-  }
+  public readonly highlighter?: CodeHighlighter;
 
-  protected highlight(style: HighlightStyle) {
-    const tokens: {token: string; color: string}[] = [];
-    highlightTree(
-      this.parsed(),
-      style,
-      (from: number, to: number, classList: string) => {
-        const rule = style.module
-          .getRules()
-          .split('\n')
-          .find(rule => rule.includes(classList));
-        const color = rule.split('color:')[1]?.split(';')[0].trim();
+  private readonly cursor = new CodeCursor(this);
 
-        if (!color) {
-          useLogger().warn(`Unknown theme class '${classList}'`);
-        }
-
-        // Make sure that all of the characters make it into the list, even
-        // if they don't make it through the parser. That shouldn't happen,
-        // but it's better to be safe than sorry.
-        while (tokens.length < to) {
-          const token = {
-            token: this.code().substring(tokens.length, tokens.length + 1),
-            color: this.fallbackColor().hex(),
-          };
-          tokens.push(token);
-        }
-
-        // Update the existing tokens with the new color and classes.
-        for (let i = from; i < to; i++) {
-          tokens[i].color = color;
-        }
-      },
-    );
-
-    // Join tokens of the same color so that we can do ligatures and such.
-    return tokens.reduce<{color: string; token: string}[]>((acc, token) => {
-      if (acc.length === 0) {
-        return [token];
-      }
-      if (acc[acc.length - 1].color === token.color) {
-        const e = acc[acc.length - 1];
-        e.token += token.token;
-      } else {
-        acc.push(token);
-      }
-      return acc;
-    }, []);
-  }
-
-  public constructor(props?: CodeProps) {
+  public constructor({highlighter, ...props}: CodeProps) {
     super({
       fontFamily: 'monospace',
       ...props,
     });
+    this.highlighter = highlighter;
   }
 
-  protected desiredSize(): SerializedVector2<DesiredLength> {
+  protected override desiredSize(): SerializedVector2<DesiredLength> {
     this.requestFontUpdate();
-    const tokens = this.tokens();
-    const ctx = this.cacheCanvas();
-    ctx.save();
-    this.applyStyle(ctx);
-    ctx.font = this.styles.font;
+    const context = this.cacheCanvas();
+    const code = this.code();
 
-    const lh = parseFloat(this.styles.lineHeight);
-    let height = lh;
-    let width = 0;
-
-    let lineWidth = 0;
-    for (const {token} of tokens) {
-      lineWidth += ctx.measureText(token).width;
-      if (token == '\n') {
-        height += lh;
-        width = Math.max(lineWidth, width);
-        lineWidth = 0;
-      }
-    }
-    ctx.restore();
-
-    return {y: height, x: width};
-  }
-
-  protected draw(context: CanvasRenderingContext2D): void {
-    // TODO: Write actual render code that's not pulled from the original
-    // CodeBlock component.
-    this.requestFontUpdate();
+    context.save();
     this.applyStyle(context);
     context.font = this.styles.font;
-    context.textBaseline = 'top';
-    const lh = parseFloat(this.styles.lineHeight);
+    this.cursor.reset(context);
+    this.cursor.measureSize(code);
+    const size = this.cursor.getSize();
+    context.restore();
+
+    return size;
+  }
+
+  protected override draw(context: CanvasRenderingContext2D): void {
+    this.requestFontUpdate();
+    this.applyStyle(context);
+    const code = this.code();
     const size = this.computedSize();
 
-    const drawToken = (token: string, position: SerializedVector2) => {
-      if (token === '\n') {
-        position.y += lh;
-        position.x = 0;
-        return;
-      }
-      const {width} = context.measureText(token);
-      context.fillText(token, position.x, position.y);
-      position.x += width;
-    };
+    context.translate(-size.width / 2, -size.height / 2);
+    context.font = this.styles.font;
+    context.textBaseline = 'top';
 
-    context.translate(size.x / -2, size.y / -2);
-    const tokens = this.tokens();
-    const position = {x: 0, y: 0};
-    for (const {token, color} of tokens) {
-      context.save();
-      context.fillStyle = color ?? '#c9d1d9';
-      drawToken(token, position);
-      context.restore();
-    }
+    this.cursor.reset(context);
+    this.cursor.drawScope(code);
+  }
+
+  protected override collectAsyncResources(): void {
+    super.collectAsyncResources();
+    this.highlighter?.initialize();
   }
 }

--- a/src/Code.tsx
+++ b/src/Code.tsx
@@ -40,6 +40,7 @@ export class Code extends Shape {
   @signal()
   public declare readonly dialect: SimpleSignal<string, this>;
 
+  @initial(Code.highlighter)
   @signal()
   public declare readonly highlighter: SimpleSignal<CodeHighlighter, this>;
 
@@ -76,7 +77,6 @@ export class Code extends Shape {
   public constructor(props: CodeProps) {
     super({
       fontFamily: 'monospace',
-      highlighter: Code.highlighter,
       ...props,
     });
   }

--- a/src/CodeCursor.ts
+++ b/src/CodeCursor.ts
@@ -8,7 +8,7 @@ import {
 } from '@motion-canvas/core';
 import {CodeScope, isCodeScope} from '@components/CodeScope';
 import {CodeFragment, parseCodeFragment} from '@components/CodeFragment';
-import {CodeToken} from '@components/CodeToken';
+import {CodeMetrics} from '@components/CodeMetrics';
 import {Code} from '@components/Code';
 import {CodeHighlighter} from '@components/CodeHighlighter';
 
@@ -236,13 +236,13 @@ export class CodeCursor {
     this.context.restore();
   }
 
-  private calculateWidth(token: CodeToken): number {
+  private calculateWidth(token: CodeMetrics): number {
     return token.newRows === 0
       ? this.cursor.x + token.lastWidth
       : token.lastWidth;
   }
 
-  private calculateMaxWidth(token: CodeToken): number {
+  private calculateMaxWidth(token: CodeMetrics): number {
     return Math.max(
       this.maxWidth,
       token.maxWidth,

--- a/src/CodeCursor.ts
+++ b/src/CodeCursor.ts
@@ -236,17 +236,17 @@ export class CodeCursor {
     this.context.restore();
   }
 
-  private calculateWidth(token: CodeMetrics): number {
-    return token.newRows === 0
-      ? this.cursor.x + token.lastWidth
-      : token.lastWidth;
+  private calculateWidth(metrics: CodeMetrics): number {
+    return metrics.newRows === 0
+      ? this.cursor.x + metrics.lastWidth
+      : metrics.lastWidth;
   }
 
-  private calculateMaxWidth(token: CodeMetrics): number {
+  private calculateMaxWidth(metrics: CodeMetrics): number {
     return Math.max(
       this.maxWidth,
-      token.maxWidth,
-      this.cursor.x + token.firstWidth,
+      metrics.maxWidth,
+      this.cursor.x + metrics.firstWidth,
     );
   }
 }

--- a/src/CodeCursor.ts
+++ b/src/CodeCursor.ts
@@ -1,0 +1,255 @@
+import {
+  clampRemap,
+  Color,
+  map,
+  SerializedVector2,
+  unwrap,
+  Vector2,
+} from '@motion-canvas/core';
+import {CodeScope, isCodeScope} from '@components/CodeScope';
+import {CodeFragment, parseCodeFragment} from '@components/CodeFragment';
+import {CodeToken} from '@components/CodeToken';
+import {Code} from '@components/Code';
+
+/**
+ * A stateful class for recursively traversing a code scope.
+ *
+ * @internal
+ */
+export class CodeCursor {
+  public cursor = new Vector2();
+  public beforeIndex = 0;
+  public afterIndex = 0;
+  private context: CanvasRenderingContext2D;
+  private monoWidth: number;
+  private maxWidth: number;
+  private lineHeight: number;
+  private fallbackFill: Color;
+  private caches: {before: unknown; after: unknown} | null;
+
+  public constructor(private readonly node: Code) {}
+
+  /**
+   * Prepare the cursor for the next traversal.
+   *
+   * @param context - The context used to measure and draw the code.
+   */
+  public reset(context: CanvasRenderingContext2D) {
+    this.context = context;
+    this.monoWidth = context.measureText('X').width;
+    this.lineHeight = parseFloat(this.node.styles.lineHeight);
+    this.cursor = new Vector2();
+    this.beforeIndex = 0;
+    this.afterIndex = 0;
+    this.maxWidth = 0;
+    this.fallbackFill = this.node.fill() as Color;
+    this.caches = this.node.highlighterCache();
+  }
+
+  /**
+   * Measure the desired size of the code scope.
+   *
+   * @remarks
+   * The result can be retrieved with {@link getSize}.
+   *
+   * @param scope - The code scope to measure.
+   */
+  public measureSize(scope: CodeScope) {
+    const progress = unwrap(scope.progress);
+    for (const wrapped of scope.fragments) {
+      const possibleFragment = unwrap(wrapped);
+      if (isCodeScope(possibleFragment)) {
+        this.measureSize(possibleFragment);
+        continue;
+      }
+
+      const fragment = parseCodeFragment(
+        possibleFragment,
+        this.context,
+        this.monoWidth,
+      );
+
+      const beforeMaxWidth = this.calculateMaxWidth(fragment.before);
+      const afterMaxWidth = this.calculateMaxWidth(fragment.after);
+
+      const maxWidth = map(beforeMaxWidth, afterMaxWidth, progress);
+      if (maxWidth > this.maxWidth) {
+        this.maxWidth = maxWidth;
+      }
+
+      const beforeEnd = this.calculateWidth(fragment.before);
+      const afterEnd = this.calculateWidth(fragment.after);
+      this.cursor.x = map(beforeEnd, afterEnd, progress);
+
+      if (this.cursor.y === 0) {
+        this.cursor.y = 1;
+      }
+
+      this.cursor.y += map(
+        fragment.before.newRows,
+        fragment.after.newRows,
+        progress,
+      );
+    }
+  }
+
+  /**
+   * Get the size measured by the cursor.
+   */
+  public getSize() {
+    return {
+      x: this.maxWidth * this.monoWidth,
+      y: this.cursor.y * this.lineHeight,
+    };
+  }
+
+  /**
+   * Draw the given code scope.
+   *
+   * @param scope - The code scope to draw.
+   */
+  public drawScope(scope: CodeScope) {
+    const progress = unwrap(scope.progress);
+    for (const wrappedFragment of scope.fragments) {
+      const possibleFragment = unwrap(wrappedFragment);
+      if (isCodeScope(possibleFragment)) {
+        this.drawScope(possibleFragment);
+        continue;
+      }
+
+      const fragment = parseCodeFragment(
+        possibleFragment,
+        this.context,
+        this.monoWidth,
+      );
+      const timingOffset = 0.8;
+      let alpha = 1;
+      let offsetY = 0;
+      if (fragment.before.content !== fragment.after.content) {
+        const mirrored = Math.abs(progress - 0.5) * 2;
+        alpha = clampRemap(1, 1 - timingOffset, 1, 0, mirrored);
+
+        offsetY = map(
+          Math.abs(fragment.after.newRows - fragment.before.newRows) / -4,
+          0,
+          mirrored,
+        );
+      }
+
+      this.drawToken(fragment, scope, this.cursor.addY(offsetY), alpha);
+
+      this.beforeIndex += fragment.before.content.length;
+      this.afterIndex += fragment.after.content.length;
+
+      this.cursor.y += map(
+        fragment.before.newRows,
+        fragment.after.newRows,
+        progress,
+      );
+
+      const beforeEnd = this.calculateWidth(fragment.before);
+      const afterEnd = this.calculateWidth(fragment.after);
+      this.cursor.x = map(beforeEnd, afterEnd, progress);
+    }
+  }
+
+  private drawToken(
+    fragment: CodeFragment,
+    scope: CodeScope,
+    offset: SerializedVector2,
+    alpha: number,
+  ) {
+    const progress = unwrap(scope.progress);
+    const code = progress < 0.5 ? fragment.before : fragment.after;
+
+    this.context.save();
+    this.context.globalAlpha *= alpha;
+    let offsetX = offset.x;
+    let width = 0;
+    let y = 0;
+    for (let i = 0; i < code.content.length; i++) {
+      let char = code.content.charAt(i);
+      if (char === '\n') {
+        y++;
+        offsetX = 0;
+        width = 0;
+        continue;
+      }
+
+      this.context.save();
+
+      const beforeHighlight =
+        this.caches &&
+        this.node.highlighter?.highlight(
+          this.beforeIndex + i,
+          this.caches.before,
+        );
+      const afterHighlight =
+        this.caches &&
+        this.node.highlighter?.highlight(
+          this.afterIndex + i,
+          this.caches.after,
+        );
+
+      const highlight = progress < 0.5 ? beforeHighlight : afterHighlight;
+      if (highlight) {
+        // Handle edge cases where the highlight style changes despite the
+        // content being the same. The code doesn't fade in and out so the color
+        // has to be interpolated to avoid jarring changes.
+        if (
+          fragment.before.content === fragment.after.content &&
+          beforeHighlight.color !== afterHighlight.color
+        ) {
+          highlight.color = Color.lerp(
+            beforeHighlight.color ?? this.fallbackFill,
+            afterHighlight.color ?? this.fallbackFill,
+            progress,
+          ).serialize();
+        }
+
+        if (highlight.color) {
+          this.context.fillStyle = highlight.color;
+        }
+
+        if (highlight.skipAhead > 1) {
+          char = code.content.slice(i, i + highlight.skipAhead);
+        }
+
+        i += char.length - 1;
+      } else {
+        while (
+          i < code.content.length - 1 &&
+          code.content.charAt(i + 1) !== '\n'
+        ) {
+          char += code.content.charAt(++i);
+        }
+      }
+
+      this.context.fillText(
+        char,
+        (offsetX + width) * this.monoWidth,
+        (offset.y + y) * this.lineHeight,
+      );
+      this.context.restore();
+
+      width += Math.round(
+        this.context.measureText(char).width / this.monoWidth,
+      );
+    }
+    this.context.restore();
+  }
+
+  private calculateWidth(token: CodeToken): number {
+    return token.newRows === 0
+      ? this.cursor.x + token.lastWidth
+      : token.lastWidth;
+  }
+
+  private calculateMaxWidth(token: CodeToken): number {
+    return Math.max(
+      this.maxWidth,
+      token.maxWidth,
+      this.cursor.x + token.firstWidth,
+    );
+  }
+}

--- a/src/CodeCursor.ts
+++ b/src/CodeCursor.ts
@@ -10,6 +10,7 @@ import {CodeScope, isCodeScope} from '@components/CodeScope';
 import {CodeFragment, parseCodeFragment} from '@components/CodeFragment';
 import {CodeToken} from '@components/CodeToken';
 import {Code} from '@components/Code';
+import {CodeHighlighter} from '@components/CodeHighlighter';
 
 /**
  * A stateful class for recursively traversing a code scope.
@@ -26,6 +27,7 @@ export class CodeCursor {
   private lineHeight: number;
   private fallbackFill: Color;
   private caches: {before: unknown; after: unknown} | null;
+  private highlighter: CodeHighlighter | null = null;
 
   public constructor(private readonly node: Code) {}
 
@@ -44,6 +46,7 @@ export class CodeCursor {
     this.maxWidth = 0;
     this.fallbackFill = this.node.fill() as Color;
     this.caches = this.node.highlighterCache();
+    this.highlighter = this.node.highlighter();
   }
 
   /**
@@ -180,16 +183,10 @@ export class CodeCursor {
 
       const beforeHighlight =
         this.caches &&
-        this.node.highlighter?.highlight(
-          this.beforeIndex + i,
-          this.caches.before,
-        );
+        this.highlighter?.highlight(this.beforeIndex + i, this.caches.before);
       const afterHighlight =
         this.caches &&
-        this.node.highlighter?.highlight(
-          this.afterIndex + i,
-          this.caches.after,
-        );
+        this.highlighter?.highlight(this.afterIndex + i, this.caches.after);
 
       const highlight = progress < 0.5 ? beforeHighlight : afterHighlight;
       if (highlight) {

--- a/src/CodeFragment.ts
+++ b/src/CodeFragment.ts
@@ -1,17 +1,21 @@
-import {CodeToken, isCodeToken, stringToToken} from '@components/CodeToken';
+import {
+  CodeMetrics,
+  isCodeMetrics,
+  measureString,
+} from '@components/CodeMetrics';
 
 export interface CodeFragment {
-  before: CodeToken;
-  after: CodeToken;
+  before: CodeMetrics;
+  after: CodeMetrics;
 }
 
 export type PossibleCodeFragment =
   | CodeFragment
-  | CodeToken
+  | CodeMetrics
   | {before: string; after: string}
   | string;
 
-export function tokenToFragment(value: CodeToken): CodeFragment {
+export function tokenToFragment(value: CodeMetrics): CodeFragment {
   return {
     before: value,
     after: value,
@@ -25,18 +29,18 @@ export function parseCodeFragment(
 ): CodeFragment {
   let fragment: CodeFragment;
   if (typeof value === 'string') {
-    fragment = tokenToFragment(stringToToken(context, monoWidth, value));
-  } else if (isCodeToken(value)) {
+    fragment = tokenToFragment(measureString(context, monoWidth, value));
+  } else if (isCodeMetrics(value)) {
     fragment = tokenToFragment(value);
   } else {
     fragment = {
       before:
         typeof value.before === 'string'
-          ? stringToToken(context, monoWidth, value.before)
+          ? measureString(context, monoWidth, value.before)
           : value.before,
       after:
         typeof value.after === 'string'
-          ? stringToToken(context, monoWidth, value.after)
+          ? measureString(context, monoWidth, value.after)
           : value.after,
     };
   }

--- a/src/CodeFragment.ts
+++ b/src/CodeFragment.ts
@@ -1,0 +1,45 @@
+import {CodeToken, isCodeToken, stringToToken} from '@components/CodeToken';
+
+export interface CodeFragment {
+  before: CodeToken;
+  after: CodeToken;
+}
+
+export type PossibleCodeFragment =
+  | CodeFragment
+  | CodeToken
+  | {before: string; after: string}
+  | string;
+
+export function tokenToFragment(value: CodeToken): CodeFragment {
+  return {
+    before: value,
+    after: value,
+  };
+}
+
+export function parseCodeFragment(
+  value: PossibleCodeFragment,
+  context: CanvasRenderingContext2D,
+  monoWidth: number,
+): CodeFragment {
+  let fragment: CodeFragment;
+  if (typeof value === 'string') {
+    fragment = tokenToFragment(stringToToken(context, monoWidth, value));
+  } else if (isCodeToken(value)) {
+    fragment = tokenToFragment(value);
+  } else {
+    fragment = {
+      before:
+        typeof value.before === 'string'
+          ? stringToToken(context, monoWidth, value.before)
+          : value.before,
+      after:
+        typeof value.after === 'string'
+          ? stringToToken(context, monoWidth, value.after)
+          : value.after,
+    };
+  }
+
+  return fragment;
+}

--- a/src/CodeFragment.ts
+++ b/src/CodeFragment.ts
@@ -15,7 +15,7 @@ export type PossibleCodeFragment =
   | {before: string; after: string}
   | string;
 
-export function tokenToFragment(value: CodeMetrics): CodeFragment {
+export function metricsToFragment(value: CodeMetrics): CodeFragment {
   return {
     before: value,
     after: value,
@@ -29,9 +29,9 @@ export function parseCodeFragment(
 ): CodeFragment {
   let fragment: CodeFragment;
   if (typeof value === 'string') {
-    fragment = tokenToFragment(measureString(context, monoWidth, value));
+    fragment = metricsToFragment(measureString(context, monoWidth, value));
   } else if (isCodeMetrics(value)) {
-    fragment = tokenToFragment(value);
+    fragment = metricsToFragment(value);
   } else {
     fragment = {
       before:

--- a/src/CodeHighlighter.ts
+++ b/src/CodeHighlighter.ts
@@ -1,0 +1,67 @@
+/**
+ * Describes the result of a highlight operation.
+ */
+export interface HighlightResult {
+  /**
+   * The color of the code at the given index.
+   */
+  color: string | null;
+
+  /**
+   * The number of characters to skip ahead.
+   *
+   * @remarks
+   * This should be used to skip to the end of the currently highlighted token.
+   * The returned style will be used for the skipped characters, and they will
+   * be drawn as one continuous string keeping emojis and ligatures intact.
+   *
+   * The returned value is the number of characters to skip ahead, not the
+   * index of the end of the token.
+   */
+  skipAhead: number;
+}
+
+/**
+ * Describes custom highlighters used by the Code node.
+ *
+ * @typeParam T - The type of the cache used by the highlighter.
+ */
+export interface CodeHighlighter<T = unknown> {
+  /**
+   * Initializes the highlighter.
+   *
+   * @remarks
+   * This method is called when collecting async resources for the node.
+   * It can be called multiple times so caching the initialization is
+   * recommended.
+   *
+   * If initialization is asynchronous, a promise should be registered using
+   * {@link DependencyContext.collectPromise} and the value of `false` should
+   * be returned. The hook will be called again when the promise resolves.
+   * This process can be repeated until the value of `true` is returned which
+   * will mark the highlighter as ready.
+   */
+  initialize(): boolean;
+
+  /**
+   * Prepares the code for highlighting.
+   *
+   * @remarks
+   * This method is called each time the code changes. It can be used to do
+   * any preprocessing of the code before highlighting. The result of this
+   * method is cached and passed to {@link highlight} when the code is
+   * highlighted.
+   *
+   * @param code - The code to prepare.
+   * @param dialect - The language in which the code is written.
+   */
+  prepare(code: string, dialect: string): T;
+
+  /**
+   * Highlights the code at the given index.
+   *
+   * @param index - The index of the code to highlight.
+   * @param cache - The result of {@link prepare}.
+   */
+  highlight(index: number, cache: T): HighlightResult;
+}

--- a/src/CodeMetrics.ts
+++ b/src/CodeMetrics.ts
@@ -1,4 +1,4 @@
-export interface CodeToken {
+export interface CodeMetrics {
   content: string;
   newRows: number;
   endColumn: number;
@@ -7,11 +7,11 @@ export interface CodeToken {
   lastWidth: number;
 }
 
-export function stringToToken(
+export function measureString(
   context: CanvasRenderingContext2D,
   monoWidth: number,
   value: string,
-): CodeToken {
+): CodeMetrics {
   const lines = value.split('\n');
   const lastLine = lines[lines.length - 1];
   const firstWidth = Math.round(
@@ -42,6 +42,6 @@ export function stringToToken(
   };
 }
 
-export function isCodeToken(value: any): value is CodeToken {
+export function isCodeMetrics(value: any): value is CodeMetrics {
   return value?.content !== undefined;
 }

--- a/src/CodeScope.ts
+++ b/src/CodeScope.ts
@@ -1,6 +1,6 @@
 import {SignalValue, unwrap} from '@motion-canvas/core';
 import {CodeFragment, PossibleCodeFragment} from '@components/CodeFragment';
-import {isCodeToken} from '@components/CodeToken';
+import {isCodeMetrics} from '@components/CodeMetrics';
 
 export interface CodeScope {
   progress: SignalValue<number>;
@@ -57,7 +57,7 @@ export function resolveScope(
       code += fragment;
     } else if (isCodeScope(fragment)) {
       code += resolveScope(fragment, isAfter);
-    } else if (isCodeToken(fragment)) {
+    } else if (isCodeMetrics(fragment)) {
       code += fragment.content;
     } else {
       code += after

--- a/src/CodeScope.ts
+++ b/src/CodeScope.ts
@@ -1,0 +1,74 @@
+import {SignalValue, unwrap} from '@motion-canvas/core';
+import {CodeFragment, PossibleCodeFragment} from '@components/CodeFragment';
+import {isCodeToken} from '@components/CodeToken';
+
+export interface CodeScope {
+  progress: SignalValue<number>;
+  fragments: Iterable<CodeTag>;
+}
+
+export type PossibleCodeScope = CodeScope | Iterable<CodeTag> | string;
+
+export type CodeTag = SignalValue<PossibleCodeFragment | CodeFragment>;
+
+export function* CODE(
+  strings: TemplateStringsArray,
+  ...tags: CodeTag[]
+): Generator<CodeTag> {
+  for (let i = 0; i < strings.length; i++) {
+    yield strings[i];
+    if (tags[i] !== undefined) {
+      yield tags[i];
+    }
+  }
+}
+
+export function isCodeScope(value: any): value is CodeScope {
+  return value?.fragments !== undefined;
+}
+
+export function parseCodeScope(value: PossibleCodeScope): CodeScope {
+  if (typeof value === 'string') {
+    return {
+      progress: 0,
+      fragments: [value],
+    };
+  }
+
+  if (Symbol.iterator in value) {
+    return {
+      progress: 0,
+      fragments: value,
+    };
+  }
+
+  return value;
+}
+
+export function resolveScope(
+  scope: CodeScope,
+  predicate: ((scope: CodeScope) => boolean) | boolean,
+): string {
+  let code = '';
+  const isAfter = typeof predicate === 'boolean' ? predicate : predicate(scope);
+  for (const wrapped of scope.fragments) {
+    const fragment = unwrap(wrapped);
+    if (typeof fragment === 'string') {
+      code += fragment;
+    } else if (isCodeScope(fragment)) {
+      code += resolveScope(fragment, predicate);
+    } else if (isCodeToken(fragment)) {
+      code += fragment.content;
+    } else {
+      code += isAfter
+        ? typeof fragment.after === 'string'
+          ? fragment.after
+          : fragment.after.content
+        : typeof fragment.before === 'string'
+          ? fragment.before
+          : fragment.before.content;
+    }
+  }
+
+  return code;
+}

--- a/src/CodeScope.ts
+++ b/src/CodeScope.ts
@@ -47,20 +47,20 @@ export function parseCodeScope(value: PossibleCodeScope): CodeScope {
 
 export function resolveScope(
   scope: CodeScope,
-  predicate: ((scope: CodeScope) => boolean) | boolean,
+  isAfter: ((scope: CodeScope) => boolean) | boolean,
 ): string {
   let code = '';
-  const isAfter = typeof predicate === 'boolean' ? predicate : predicate(scope);
+  const after = typeof isAfter === 'boolean' ? isAfter : isAfter(scope);
   for (const wrapped of scope.fragments) {
     const fragment = unwrap(wrapped);
     if (typeof fragment === 'string') {
       code += fragment;
     } else if (isCodeScope(fragment)) {
-      code += resolveScope(fragment, predicate);
+      code += resolveScope(fragment, isAfter);
     } else if (isCodeToken(fragment)) {
       code += fragment.content;
     } else {
-      code += isAfter
+      code += after
         ? typeof fragment.after === 'string'
           ? fragment.after
           : fragment.after.content

--- a/src/CodeToken.ts
+++ b/src/CodeToken.ts
@@ -1,0 +1,47 @@
+export interface CodeToken {
+  content: string;
+  newRows: number;
+  endColumn: number;
+  firstWidth: number;
+  maxWidth: number;
+  lastWidth: number;
+}
+
+export function stringToToken(
+  context: CanvasRenderingContext2D,
+  monoWidth: number,
+  value: string,
+): CodeToken {
+  const lines = value.split('\n');
+  const lastLine = lines[lines.length - 1];
+  const firstWidth = Math.round(
+    context.measureText(lines[0]).width / monoWidth,
+  );
+  let lastWidth = firstWidth;
+  let maxWidth = firstWidth;
+
+  for (let i = 1; i < lines.length - 1; i++) {
+    const line = lines[i];
+    const width = Math.round(context.measureText(line).width / monoWidth);
+    if (width > maxWidth) {
+      maxWidth = width;
+    }
+  }
+
+  if (lines.length > 0) {
+    lastWidth = Math.round(context.measureText(lastLine).width / monoWidth);
+  }
+
+  return {
+    content: value,
+    newRows: lines.length - 1,
+    endColumn: lastLine.length,
+    firstWidth,
+    maxWidth,
+    lastWidth,
+  };
+}
+
+export function isCodeToken(value: any): value is CodeToken {
+  return value?.content !== undefined;
+}

--- a/src/DefaultHighlightStyle.ts
+++ b/src/DefaultHighlightStyle.ts
@@ -1,0 +1,98 @@
+import {HighlightStyle} from '@codemirror/language';
+import {tags as t} from '@lezer/highlight';
+
+export const DefaultHighlightStyle = HighlightStyle.define([
+  {tag: t.keyword, color: '#5e81ac'},
+  {
+    tag: [t.name, t.deleted, t.character, t.propertyName, t.macroName],
+    color: '#88c0d0',
+  },
+  {tag: [t.variableName], color: '#8fbcbb'},
+  {tag: [t.function(t.variableName)], color: '#8fbcbb'},
+  {tag: [t.labelName], color: '#81a1c1'},
+  {
+    tag: [t.color, t.constant(t.name), t.standard(t.name)],
+    color: '#5e81ac',
+  },
+  {tag: [t.definition(t.name), t.separator], color: '#a3be8c'},
+  {tag: [t.brace], color: '#8fbcbb'},
+  {
+    tag: [t.annotation],
+    color: '#d30102',
+  },
+  {
+    tag: [t.number, t.changed, t.annotation, t.modifier, t.self, t.namespace],
+    color: '#b48ead',
+  },
+  {
+    tag: [t.typeName, t.className],
+    color: '#ECEFF4',
+  },
+  {
+    tag: [t.operator, t.operatorKeyword],
+    color: '#a3be8c',
+  },
+  {
+    tag: [t.tagName],
+    color: '#b48ead',
+  },
+  {
+    tag: [t.squareBracket],
+    color: '#ECEFF4',
+  },
+  {
+    tag: [t.angleBracket],
+    color: '#ECEFF4',
+  },
+  {
+    tag: [t.attributeName],
+    color: '#eceff4',
+  },
+  {
+    tag: [t.regexp],
+    color: '#5e81ac',
+  },
+  {
+    tag: [t.quote],
+    color: '#b48ead',
+  },
+  {tag: [t.string], color: '#a3be8c'},
+  {
+    tag: t.link,
+    color: '#a3be8c',
+    textDecoration: 'underline',
+    textUnderlinePosition: 'under',
+  },
+  {
+    tag: [t.url, t.escape, t.special(t.string)],
+    color: '#8fbcbb',
+  },
+  {tag: [t.meta], color: '#88c0d0'},
+  {tag: [t.monospace], color: '#d8dee9', fontStyle: 'italic'},
+  {tag: [t.comment], color: '#4c566a', fontStyle: 'italic'},
+  {tag: t.strong, fontWeight: 'bold', color: '#5e81ac'},
+  {tag: t.emphasis, fontStyle: 'italic', color: '#5e81ac'},
+  {tag: t.strikethrough, textDecoration: 'line-through'},
+  {tag: t.heading, fontWeight: 'bold', color: '#5e81ac'},
+  {tag: t.special(t.heading1), fontWeight: 'bold', color: '#5e81ac'},
+  {tag: t.heading1, fontWeight: 'bold', color: '#5e81ac'},
+  {
+    tag: [t.heading2, t.heading3, t.heading4],
+    fontWeight: 'bold',
+    color: '#5e81ac',
+  },
+  {
+    tag: [t.heading5, t.heading6],
+    color: '#5e81ac',
+  },
+  {tag: [t.atom, t.bool, t.special(t.variableName)], color: '#d08770'},
+  {
+    tag: [t.processingInstruction, t.inserted],
+    color: '#8fbcbb',
+  },
+  {
+    tag: [t.contentSeparator],
+    color: '#ebcb8b',
+  },
+  {tag: t.invalid, color: '#434c5e', borderBottom: `1px dotted #d30102`},
+]);

--- a/src/LezerHighlighter.ts
+++ b/src/LezerHighlighter.ts
@@ -97,6 +97,10 @@ export class LezerHighlighter implements CodeHighlighter<LezerCache | null> {
   }
 
   private getNodeId(node: SyntaxNode): number {
+    if (!node.parent) {
+      return -1;
+    }
+
     // NOTE: They don't want us to know about this property.
     // We need a way to persistently identify nodes and this seems to work.
     // Perhaps it could break if the tree is edited? But we don't do that. Yet.

--- a/src/LezerHighlighter.ts
+++ b/src/LezerHighlighter.ts
@@ -1,0 +1,105 @@
+import {CodeHighlighter, HighlightResult} from './CodeHighlighter';
+import {highlightTree} from '@lezer/highlight';
+import {Parser, SyntaxNode, Tree} from '@lezer/common';
+import {parser as jsParser} from '@lezer/javascript';
+import {HighlightStyle} from '@codemirror/language';
+import {useLogger} from '@motion-canvas/core';
+
+interface LezerCache {
+  tree: Tree;
+  code: string;
+  colorLookup: Map<number, string>;
+}
+
+export class LezerHighlighter implements CodeHighlighter<LezerCache | null> {
+  private static classRegex = /\.(\S+).*color:([^;]+)/;
+  private readonly classLookup = new Map<string, string>();
+
+  public constructor(
+    private readonly style: HighlightStyle,
+    private readonly parserMap: Map<string, Parser> = new Map([
+      ['javascript', jsParser],
+      ['js', jsParser],
+    ]),
+  ) {
+    for (const rule of this.style.module.getRules().split('\n')) {
+      const match = rule.match(LezerHighlighter.classRegex);
+      if (!match) {
+        continue;
+      }
+
+      const className = match[1];
+      const color = match[2].trim();
+      this.classLookup.set(className, color);
+    }
+  }
+
+  public initialize(): boolean {
+    return true;
+  }
+
+  public prepare(code: string, dialect: string): LezerCache | null {
+    const parser = this.parserMap.get(dialect);
+    if (!parser) {
+      useLogger().warn(`No parser found for dialect: ${dialect}`);
+      return null;
+    }
+
+    const colorLookup = new Map<number, string>();
+    const tree = parser.parse(code);
+    highlightTree(tree, this.style, (from, to, classes) => {
+      const color = this.classLookup.get(classes);
+      if (!color) {
+        return;
+      }
+
+      const cursor = tree.cursorAt(from, 1);
+      do {
+        const id = this.getNodeId(cursor.node);
+        colorLookup.set(id, color);
+      } while (cursor.next() && cursor.to <= to);
+    });
+
+    return {
+      tree,
+      code,
+      colorLookup,
+    };
+  }
+
+  public highlight(index: number, cache: LezerCache | null): HighlightResult {
+    if (!cache) {
+      return {
+        color: null,
+        skipAhead: 0,
+      };
+    }
+
+    const node = cache.tree.resolveInner(index, 1);
+    const id = this.getNodeId(node);
+    const color = cache.colorLookup.get(id);
+    if (color) {
+      return {
+        color,
+        skipAhead: node.to - index,
+      };
+    }
+
+    let skipAhead = 0;
+    if (!node.firstChild) {
+      skipAhead = node.to - index;
+    }
+
+    return {
+      color: null,
+      skipAhead,
+    };
+  }
+
+  private getNodeId(node: SyntaxNode): number {
+    // NOTE: They don't want us to know about this property.
+    // We need a way to persistently identify nodes and this seems to work.
+    // Perhaps it could break if the tree is edited? But we don't do that. Yet.
+    return (node as any).index;
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,3 @@
 export * from './Code';
+export {CODE} from './CodeScope';
+export * from './LezerHighlighter';

--- a/test/src/scenes/test.tsx
+++ b/test/src/scenes/test.tsx
@@ -110,104 +110,6 @@ export default makeScene2D(function* (view) {
     {tag: t.invalid, color: '#606f7a', borderBottom: `1px dotted #ff5f52`},
   ]);
 
-  const nordHighlightStyle = HighlightStyle.define([
-    {tag: t.keyword, color: '#5e81ac'},
-    {
-      tag: [t.name, t.deleted, t.character, t.propertyName, t.macroName],
-      color: '#88c0d0',
-    },
-    {tag: [t.variableName], color: '#8fbcbb'},
-    {tag: [t.function(t.variableName)], color: '#8fbcbb'},
-    {tag: [t.labelName], color: '#81a1c1'},
-    {
-      tag: [t.color, t.constant(t.name), t.standard(t.name)],
-      color: '#5e81ac',
-    },
-    {tag: [t.definition(t.name), t.separator], color: '#a3be8c'},
-    {tag: [t.brace], color: '#8fbcbb'},
-    {
-      tag: [t.annotation],
-      color: '#d30102',
-    },
-    {
-      tag: [t.number, t.changed, t.annotation, t.modifier, t.self, t.namespace],
-      color: '#b48ead',
-    },
-    {
-      tag: [t.typeName, t.className],
-      color: '#ECEFF4',
-    },
-    {
-      tag: [t.operator, t.operatorKeyword],
-      color: '#a3be8c',
-    },
-    {
-      tag: [t.tagName],
-      color: '#b48ead',
-    },
-    {
-      tag: [t.squareBracket],
-      color: '#ECEFF4',
-    },
-    {
-      tag: [t.angleBracket],
-      color: '#ECEFF4',
-    },
-    {
-      tag: [t.attributeName],
-      color: '#eceff4',
-    },
-    {
-      tag: [t.regexp],
-      color: '#5e81ac',
-    },
-    {
-      tag: [t.quote],
-      color: '#b48ead',
-    },
-    {tag: [t.string], color: '#a3be8c'},
-    {
-      tag: t.link,
-      color: '#a3be8c',
-      textDecoration: 'underline',
-      textUnderlinePosition: 'under',
-    },
-    {
-      tag: [t.url, t.escape, t.special(t.string)],
-      color: '#8fbcbb',
-    },
-    {tag: [t.meta], color: '#88c0d0'},
-    {tag: [t.monospace], color: '#d8dee9', fontStyle: 'italic'},
-    {tag: [t.comment], color: '#4c566a', fontStyle: 'italic'},
-    {tag: t.strong, fontWeight: 'bold', color: '#5e81ac'},
-    {tag: t.emphasis, fontStyle: 'italic', color: '#5e81ac'},
-    {tag: t.strikethrough, textDecoration: 'line-through'},
-    {tag: t.heading, fontWeight: 'bold', color: '#5e81ac'},
-    {tag: t.special(t.heading1), fontWeight: 'bold', color: '#5e81ac'},
-    {tag: t.heading1, fontWeight: 'bold', color: '#5e81ac'},
-    {
-      tag: [t.heading2, t.heading3, t.heading4],
-      fontWeight: 'bold',
-      color: '#5e81ac',
-    },
-    {
-      tag: [t.heading5, t.heading6],
-      color: '#5e81ac',
-    },
-    {tag: [t.atom, t.bool, t.special(t.variableName)], color: '#d08770'},
-    {
-      tag: [t.processingInstruction, t.inserted],
-      color: '#8fbcbb',
-    },
-    {
-      tag: [t.contentSeparator],
-      color: '#ebcb8b',
-    },
-    {tag: t.invalid, color: '#434c5e', borderBottom: `1px dotted #d30102`},
-  ]);
-
-  const highlighter = new LezerHighlighter(nordHighlightStyle);
-
   view.add(
     <Txt
       fontSize={48}
@@ -222,7 +124,6 @@ export default makeScene2D(function* (view) {
   view.add(
     <Code
       ref={c}
-      highlighter={highlighter}
       dialect="js"
       x={0}
       y={0}
@@ -271,12 +172,12 @@ export default makeScene2D(function* (view) {
   yield txt().text('CJK and UTF-8 Characters', 1);
   yield* c().code(
     `
-// Note that these do not work in GitHub Actions
-// where this gif is rendered.
-// 私🦀です
-function crab() {
-  console.log('🦀')
-}`,
+                            // Note that these do not work in GitHub Actions
+                            // where this gif is rendered.
+                            // 私🦀です
+                            function crab() {
+                              console.log('🦀')
+                            }`,
     1,
   );
 
@@ -300,9 +201,9 @@ function crab() {
 
   yield* waitFor(2);
 
-  // TODO: Reimplement via CodeHighlighter
-  // yield txt().text('Color Themes', 1);
-  // yield* c().style(materialHighlightStyle, 1);
+  yield txt().text('Color Themes', 1);
+  yield* waitFor(0.5);
+  c().highlighter(new LezerHighlighter(materialHighlightStyle));
 
   yield* waitFor(2);
 });


### PR DESCRIPTION
Implements the foundation for code transitions without the nice helper methods yet.
The idea is to describe transitions using an array of code fragments together with the corresponding progress of the transition in a structure called `CodeScope`:
```ts
{
  progress: 0.5,
  fragments: [
    { // adding code:
      before: '',
      after: 'const a = 1;',
    },
    { // removing code:
      before: 'const b = 2;',
      after: '',
    },
    { // modifying code:
      before: 'const c = 3;',
      after: 'const d = 4;',
    },
    // retaining the same code:
    'const e = 5;',
  ],
}
```
A valid fragment can be either a string, a `before`/`after` pair, another code scope, or a function returning any of those (a signal value). In the final version, these scopes will be constructed by helper methods.
The basic recipe for tweening would be:
1. Construct the fragments (diffing algorithm, `edit` method, `append`, etc)
2. Set the progress to `0`.
3. Tween the progress towards `1`.
4. Replace the fragments with the simplest representation. (replace `before`/`after` pairs with strings, merge fragments, etc.)

The ability to nest code scopes within each other will allow code signals to animate independently.


Certain limitations apply:
- No ability to move code. Impossible to use with patience diff plus, only the base one.
- A nested code scope cannot be tweened while the parent scope is tweened as well. When the parent scope starts being tweened it takes a snapshot of all its fragments so any scopes nested within will stop animating.

Unlike `code-fns`, this solution uses relative positioning for animations. Instead of tweening the x and y position we tween the height (number of new lines in the fragment) and the end column (number of characters in the last line). This makes the transition relative to the code scope and lets us calculate them independently.